### PR TITLE
Upload Jacoco Report as an artifact in Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,3 +64,5 @@ check_android_task:
     androidtest_artifacts:
       path: "./app/build/outputs/**/*.xml"
       format: junit
+    jacoco_test_report_artifacts:
+      path: "./app/build/reports/jacoco/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -65,4 +65,4 @@ check_android_task:
       path: "./app/build/outputs/**/*.xml"
       format: junit
     jacoco_test_report_artifacts:
-      path: "./app/build/reports/jacoco/*"
+      path: "./app/build/reports/jacoco/**"


### PR DESCRIPTION
We are missing details about the Jacoco Test Coverage result. This PR adds the report as an artifact in Cirrus.

This helps understand where test coverage is missing and the only way to do so for now is by generating the report locally and checking it there (not efficient :-/ )