### PR TITLE
adapting cache manager

### DIFF
--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -52,6 +52,13 @@ public class CacheManagerTest {
        Future<Boolean> inserted= manager.insert(post);
        assertTrue(inserted.get());
     }
+    @Test
+    public void insertAllOfValidPostIsSuccessful() throws Exception {
+        Post post1= new SimpleTestPost();
+        Post post2= new SimpleTestPost("Another Valid one");
+        Future<Boolean> inserted= manager.insertAll(post1,post2);
+        assertTrue(inserted.get());
+    }
 
     @Test
     public void insertOfInvalidPostIsUnsuccessful() throws ExecutionException, InterruptedException {

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -171,6 +171,15 @@ public class CacheManagerTest {
     }
 
     @Test
+    public void NoSportNoCache() throws ExecutionException, InterruptedException {
+        Post post= SimpleTestPost.postWith("I don't play soccer, i prefer rowing",
+                new Timestamp(Calendar.getInstance().get(Calendar.YEAR),
+                        Month.values()[0], 1, 8, 1, Timestamp.Meridiem.PM)
+                ,new Location("Lausanne", 10, 10),10, null);
+        assertFalse(manager.insert(post).get());
+    }
+
+    @Test
     public  void userPresentUIDCachedCorrectly() throws ExecutionException, InterruptedException {
         DummyUser user = new DummyUser("i play football");
         Post post = SimpleTestPost.postWith("Looking for football team",

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -24,7 +24,6 @@ public class CacheManagerTest {
     @Test
     public void onePlusOneIsTwo(){
         assertTrue(1+1==2);
-
     }
     /*
     private CacheManager manager;

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -113,16 +113,14 @@ public class CacheManagerTest {
 
     @Test
     public void randomSelectEmptyCache() throws ExecutionException, InterruptedException {
-        assertTrue(manager.randomSelect().get()==null);
+        assertTrue(manager.randomSelect().get().isEmpty());
     }
 
     @Test
     public void randomSelectRetrievesPosts() throws ExecutionException, InterruptedException {
         SimpleTestPost post =  new SimpleTestPost("only one to select");
-
         manager.insert(post).get();
-
-        Post retrieved = manager.randomSelect().get();
+        Post retrieved = manager.randomSelect().get().get(0);
         assertTrue(post.equals(retrieved));
     }
 

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -33,11 +33,6 @@ import java.util.stream.Collectors;
 public class CacheManagerTest {
     @Rule
     public ActivityScenarioRule<MainActivity> testRule = new ActivityScenarioRule<>(MainActivity.class);
-    @Test
-    public void onePlusOneIsTwo(){
-        assertTrue(1+1==2);
-    }
-
 
     private CacheManager manager;
 

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -18,8 +18,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 @RunWith(AndroidJUnit4.class)
 public class CacheManagerTest {
@@ -124,5 +126,21 @@ public class CacheManagerTest {
         SimpleTestPost post =  new SimpleTestPost("to fetch");
         manager.insert(post).get();
         assertTrue(post.equals(manager.getAllPosts().get().get(0)));
+    }
+
+    @Test
+    public void fetchAllByIdsRetrievesCorrectPost() throws ExecutionException, InterruptedException {
+        Post post1 =  new SimpleTestPost("to fetch");
+        Post post2= new SimpleTestPost("Valid");
+        manager.insertAll(post1,post2).get();
+        List<String> retrieved= manager.fetchAllByIds(CachedPost.computeID(post1),CachedPost.computeID(post2))
+                                .get().stream().map(p -> p.getTitle())
+                                .collect(Collectors.toList());
+        assertTrue(retrieved.contains(post1.getTitle())&&retrieved.contains(post2.getTitle()));
+    }
+
+    @Test
+    public void fetchAllByIdsUnavailablePosts() throws ExecutionException, InterruptedException {
+        assertTrue(manager.fetchAllByIds(CachedPost.EMPTY_ID).get().isEmpty());
     }
 }

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -53,18 +53,28 @@ public class CacheManagerTest {
        assertTrue(inserted.get());
     }
     @Test
-    public void insertAllOfValidPostIsSuccessful() throws Exception {
+    public void insertAllOfValidPostsIsSuccessful() throws Exception {
         Post post1= new SimpleTestPost();
         Post post2= new SimpleTestPost("Another Valid one");
         Future<Boolean> inserted= manager.insertAll(post1,post2);
         assertTrue(inserted.get());
     }
 
+
     @Test
     public void insertOfInvalidPostIsUnsuccessful() throws ExecutionException, InterruptedException {
         assertFalse(manager.insert(null).get());
     }
 
+    @Test
+    public void insertAllOfInvalidPostsIsUnsuccessful() throws ExecutionException, InterruptedException {
+        assertFalse(manager.insertAll(null,null).get());
+    }
+
+    @Test
+    public void insertAllOfInvalidAndValidPostsIsUnsuccessful() throws ExecutionException, InterruptedException {
+        assertFalse(manager.insertAll(null,new SimpleTestPost()).get());
+    }
     @Test
     public void CacheManagerIsUnique() {
         CacheManager secondManager= CacheManager.getCacheManager(ApplicationProvider.getApplicationContext());

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -21,6 +21,11 @@ import java.util.concurrent.Future;
 
 @RunWith(AndroidJUnit4.class)
 public class CacheManagerTest {
+    @Test
+    void onePlusOneIsTwo(){
+        assertTrue(1+1==2);
+
+    }
     /*
     private CacheManager manager;
 

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 @RunWith(AndroidJUnit4.class)
 public class CacheManagerTest {
     @Test
-    void onePlusOneIsTwo(){
+    public void onePlusOneIsTwo(){
         assertTrue(1+1==2);
 
     }

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Future;
 
 @RunWith(AndroidJUnit4.class)
 public class CacheManagerTest {
+    /*
     private CacheManager manager;
 
     @Before
@@ -76,4 +77,6 @@ public class CacheManagerTest {
     public void fetchUnavailablePost() throws ExecutionException, InterruptedException {
         assertTrue(manager.fetch(CachedPost.emptyID).get()==null);
     }
+    */
+
 }

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -111,6 +111,20 @@ public class CacheManagerTest {
         assertTrue(manager.fetch(CachedPost.EMPTY_ID).get()==null);
     }
 
+    @Test
+    public void randomSelectEmptyCache() throws ExecutionException, InterruptedException {
+        assertTrue(manager.randomSelect().get()==null);
+    }
+
+    @Test
+    public void randomSelectRetrievesPosts() throws ExecutionException, InterruptedException {
+        SimpleTestPost post =  new SimpleTestPost("only one to select");
+
+        manager.insert(post).get();
+
+        Post retrieved = manager.randomSelect().get();
+        assertTrue(post.equals(retrieved));
+    }
 
     @Test
     public void databaseISOpen() {

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.github.versus.offline.CacheManager;
@@ -13,6 +14,7 @@ import com.github.versus.posts.Post;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -21,11 +23,14 @@ import java.util.concurrent.Future;
 
 @RunWith(AndroidJUnit4.class)
 public class CacheManagerTest {
+    @Rule
+    public ActivityScenarioRule<MainActivity> testRule = new ActivityScenarioRule<>(MainActivity.class);
     @Test
     public void onePlusOneIsTwo(){
         assertTrue(1+1==2);
     }
-    /*
+
+
     private CacheManager manager;
 
     @Before
@@ -35,8 +40,10 @@ public class CacheManagerTest {
 
 
     @After
-    public void clearDb() {
-        manager.getDb().clearAllTables();
+    public void ClearAndClose() {
+        manager.clearDB();
+        manager= null;
+
     }
 
     @Test
@@ -60,7 +67,9 @@ public class CacheManagerTest {
     @Test
     public void fetchRetrievesTheRightPost() throws ExecutionException, InterruptedException {
         SimpleTestPost post =  new SimpleTestPost("to fetch");
+
         manager.insert(post).get();
+
         Post retrieved = manager.fetch(CachedPost.computeID(post)).get();
         assertTrue(post.equals(retrieved));
     }
@@ -79,8 +88,12 @@ public class CacheManagerTest {
 
     @Test
     public void fetchUnavailablePost() throws ExecutionException, InterruptedException {
-        assertTrue(manager.fetch(CachedPost.emptyID).get()==null);
+        assertTrue(manager.fetch(CachedPost.EMPTY_ID).get()==null);
     }
-    */
 
+
+    @Test
+    public void databaseISOpen() {
+        assertTrue(manager.DBAvailable());
+    }
 }

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -113,4 +113,16 @@ public class CacheManagerTest {
     public void databaseISOpen() {
         assertTrue(manager.DBAvailable());
     }
+
+    @Test
+    public void getAllPostsWorksWhenNoPostIsPresent() throws ExecutionException, InterruptedException {
+        assertTrue(manager.getAllPosts().get().size()==0);
+    }
+
+    @Test
+    public void getAllPostsRetrievesPostsCorrectly() throws ExecutionException, InterruptedException {
+        SimpleTestPost post =  new SimpleTestPost("to fetch");
+        manager.insert(post).get();
+        assertTrue(post.equals(manager.getAllPosts().get().get(0)));
+    }
 }

--- a/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
+++ b/app/src/androidTest/java/com/github/versus/CacheManagerTest.java
@@ -10,7 +10,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.github.versus.offline.CacheManager;
 import com.github.versus.offline.CachedPost;
 import com.github.versus.offline.SimpleTestPost;
+import com.github.versus.posts.Location;
 import com.github.versus.posts.Post;
+import com.github.versus.posts.Timestamp;
+import com.github.versus.sports.Sport;
 
 import org.junit.After;
 import org.junit.Before;
@@ -18,6 +21,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -143,4 +149,18 @@ public class CacheManagerTest {
     public void fetchAllByIdsUnavailablePosts() throws ExecutionException, InterruptedException {
         assertTrue(manager.fetchAllByIds(CachedPost.EMPTY_ID).get().isEmpty());
     }
+
+    @Test
+    public void sportsAreCachedCorrectly() throws ExecutionException, InterruptedException {
+        Post post= SimpleTestPost.postWith("I don't play soccer, i prefer rowing",
+        new Timestamp(Calendar.getInstance().get(Calendar.YEAR),
+                Month.values()[0], 1, 8, 1, Timestamp.Meridiem.PM)
+                ,new Location("Lausanne", 10, 10),10, Sport.ClIMBING);
+
+        String key= CachedPost.computeID(post);
+        manager.insert(post).get();
+        Post fetched =manager.fetch(key).get();
+        assertTrue(fetched.getSport()==post.getSport());
+    }
+
 }

--- a/app/src/main/java/com/github/versus/offline/CacheManager.java
+++ b/app/src/main/java/com/github/versus/offline/CacheManager.java
@@ -6,6 +6,7 @@ import androidx.room.Room;
 
 import com.github.versus.db.DataBaseManager;
 import com.github.versus.posts.Post;
+import com.github.versus.sports.Sport;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -85,6 +86,11 @@ public final class CacheManager implements DataBaseManager<Post> {
 
     public Future<Post> randomSelect(){
         return CompletableFuture.supplyAsync(()->dao.randomSelect().revert())
+                .handle((r,e)-> e==null? r:null);
+    }
+
+    public Future<Post> loadBySport(Sport sport){
+        return CompletableFuture.supplyAsync(()->dao.loadBySport(sport.name()).revert())
                 .handle((r,e)-> e==null? r:null);
     }
 

--- a/app/src/main/java/com/github/versus/offline/CacheManager.java
+++ b/app/src/main/java/com/github/versus/offline/CacheManager.java
@@ -78,7 +78,14 @@ public final class CacheManager implements DataBaseManager<Post> {
     public Future<List<Post>> getAllPosts(){
         return CompletableFuture.supplyAsync(()-> dao.getAll().stream()
                         .map(cachedPost -> cachedPost.revert()).collect(Collectors.toList()))
+
+
                         .handle((r,e)-> e==null ? r:null);
+    }
+
+    public Future<Post> randomSelect(){
+        return CompletableFuture.supplyAsync(()->dao.randomSelect().revert())
+                .handle((r,e)-> e==null? r:null);
     }
 
     public void clearDB(){

--- a/app/src/main/java/com/github/versus/offline/CacheManager.java
+++ b/app/src/main/java/com/github/versus/offline/CacheManager.java
@@ -68,7 +68,7 @@ public final class CacheManager implements DataBaseManager<Post> {
                 .handle((r,e)-> e==null);
     }
 
-    public Future<List<Post>> loadAllByIds(String ids[]){
+    public Future<List<Post>> fetchAllByIds(String ...ids){
         return CompletableFuture.supplyAsync(()->dao.loadAllByIds(ids).stream()
                         .map(cachedPost -> cachedPost.revert()).collect(Collectors.toList()))
                         .handle((r,e)-> e==null? r:null);

--- a/app/src/main/java/com/github/versus/offline/CacheManager.java
+++ b/app/src/main/java/com/github/versus/offline/CacheManager.java
@@ -84,9 +84,10 @@ public final class CacheManager implements DataBaseManager<Post> {
                         .handle((r,e)-> e==null ? r:null);
     }
 
-    public Future<Post> randomSelect(){
-        return CompletableFuture.supplyAsync(()->dao.randomSelect().revert())
-                .handle((r,e)-> e==null? r:null);
+    public Future<List<Post>> randomSelect(){
+        return CompletableFuture.supplyAsync(()->dao.randomSelect().stream()
+                        .map(cachedPost ->cachedPost.revert()).collect(Collectors.toList()))
+                        .handle((r,e)-> e==null? r:null);
     }
 
     public Future<Post> loadBySport(Sport sport){

--- a/app/src/main/java/com/github/versus/offline/CacheManager.java
+++ b/app/src/main/java/com/github/versus/offline/CacheManager.java
@@ -81,5 +81,14 @@ public final class CacheManager implements DataBaseManager<Post> {
                         .handle((r,e)-> e==null ? r:null);
     }
 
+    public void clearDB(){
+        db.clearAllTables();
+    }
+
+
+    public boolean DBAvailable(){
+        return db.isOpen();
+    }
+
 
 }

--- a/app/src/main/java/com/github/versus/offline/CachedPost.java
+++ b/app/src/main/java/com/github/versus/offline/CachedPost.java
@@ -65,7 +65,8 @@ public final class CachedPost {
     @ColumnInfo(name = "sport")
     public String sport;
 
-    @ColumnInfo()
+    @ColumnInfo(name = "userID")
+    public String uid;
     public static final String EMPTY_ID = "Empty";
     private CachedPost(Post post){
 
@@ -85,6 +86,7 @@ public final class CachedPost {
         seconds= timestamp.getSeconds();
         meridiem= timestamp.getMeridiem().name();
         sport= post.getSport().name();
+        uid= post.getPlayers().size()==0?null:post.getPlayers().get(0).getUID();
         isEmpty= false;
 
     }
@@ -103,7 +105,11 @@ public final class CachedPost {
     public Post revert(){
         Timestamp timestamp= new Timestamp(year,Month.valueOf(month),day,hour,minutes, Timestamp.Meridiem.valueOf(meridiem));
         Location location = new Location(locationName,latitude,longitude);
-        return new  Post(title, timestamp, location, new ArrayList<>(),  limit, Sport.valueOf(sport));
+        List<DummyUser> postCreator= new ArrayList<>();
+        if(uid!=null) {
+            postCreator.add(new DummyUser(uid));
+        }
+        return new  Post(title, timestamp, location,postCreator,  limit, Sport.valueOf(sport));
     }
 
     public static String computeID(Post post){

--- a/app/src/main/java/com/github/versus/offline/CachedPost.java
+++ b/app/src/main/java/com/github/versus/offline/CachedPost.java
@@ -8,9 +8,11 @@ import androidx.room.PrimaryKey;
 import com.github.versus.posts.Location;
 import com.github.versus.posts.Post;
 import com.github.versus.posts.Timestamp;
+import com.github.versus.sports.Sport;
 import com.github.versus.user.DummyUser;
 
 import java.time.Month;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -94,37 +96,9 @@ public final class CachedPost {
     }
 
     public Post revert(){
-        return new Post() {
-            @Override
-            public String getTitle() {
-                return title;
-            }
-
-            @Override
-            public Timestamp getDate() {
-                return new Timestamp(year,Month.valueOf(month),day,hour,minutes, Timestamp.Meridiem.valueOf(meridiem));
-            }
-
-            @Override
-            public Location getLocation() {
-                return new Location(locationName,latitude,longitude);
-            }
-
-            @Override
-            public List<DummyUser> getPlayers() {
-                 throw new RuntimeException("Not implemented");
-            }
-
-            @Override
-            public int getPlayerLimit() {
-                return limit;
-            }
-
-            @Override
-            public Map<String, Object> getAllAttributes() {
-                throw  new RuntimeException("Not Implemented");
-            }
-        };
+        Timestamp timestamp= new Timestamp(year,Month.valueOf(month),day,hour,minutes, Timestamp.Meridiem.valueOf(meridiem));
+        Location location = new Location(locationName,latitude,longitude);
+        return new  Post(title, timestamp, location, new ArrayList<>(),  limit, Sport.SOCCER);
     }
 
     public static String computeID(Post post){

--- a/app/src/main/java/com/github/versus/offline/CachedPost.java
+++ b/app/src/main/java/com/github/versus/offline/CachedPost.java
@@ -59,9 +59,13 @@ public final class CachedPost {
     @ColumnInfo(name = "meridiem")
     public  String  meridiem;
 
-
     @ColumnInfo(name = "empty")
     public  boolean  isEmpty;
+
+    @ColumnInfo(name = "sport")
+    public String sport;
+
+    @ColumnInfo()
     public static final String EMPTY_ID = "Empty";
     private CachedPost(Post post){
 
@@ -80,6 +84,7 @@ public final class CachedPost {
         minutes= timestamp.getMinutes();
         seconds= timestamp.getSeconds();
         meridiem= timestamp.getMeridiem().name();
+        sport= post.getSport().name();
         isEmpty= false;
 
     }
@@ -98,7 +103,7 @@ public final class CachedPost {
     public Post revert(){
         Timestamp timestamp= new Timestamp(year,Month.valueOf(month),day,hour,minutes, Timestamp.Meridiem.valueOf(meridiem));
         Location location = new Location(locationName,latitude,longitude);
-        return new  Post(title, timestamp, location, new ArrayList<>(),  limit, Sport.SOCCER);
+        return new  Post(title, timestamp, location, new ArrayList<>(),  limit, Sport.valueOf(sport));
     }
 
     public static String computeID(Post post){
@@ -109,7 +114,7 @@ public final class CachedPost {
     }
 
     public static boolean postIsInvalid(Post post){
-        return post==null||post.getTitle()==null||post.getLocation()==null||post.getDate()==null;
+        return post==null||post.getTitle()==null||post.getLocation()==null||post.getDate()==null || post.getSport()==null;
     }
 
 }

--- a/app/src/main/java/com/github/versus/offline/CachedPost.java
+++ b/app/src/main/java/com/github/versus/offline/CachedPost.java
@@ -19,7 +19,8 @@ import java.util.Map;
 @Entity
 public final class CachedPost {
 
-    @PrimaryKey @NonNull
+    @PrimaryKey(autoGenerate = false)
+    @NonNull
     public  String id;
     @ColumnInfo(name = "title")
     public  String title;
@@ -59,7 +60,7 @@ public final class CachedPost {
 
     @ColumnInfo(name = "empty")
     public  boolean  isEmpty;
-    public static final String emptyID= "Empty";
+    public static final String EMPTY_ID = "Empty";
     private CachedPost(Post post){
 
         id= computeID(post);
@@ -82,7 +83,7 @@ public final class CachedPost {
     }
     public CachedPost(){
         isEmpty= true;
-        id= emptyID;
+        id= EMPTY_ID;
     }
 
     public static CachedPost match(Post post){
@@ -128,7 +129,7 @@ public final class CachedPost {
 
     public static String computeID(Post post){
         if(postIsInvalid(post)){
-            return emptyID;
+            return EMPTY_ID;
         }
         return String.valueOf(post.getTitle().hashCode());
     }

--- a/app/src/main/java/com/github/versus/offline/PostDAO.java
+++ b/app/src/main/java/com/github/versus/offline/PostDAO.java
@@ -21,7 +21,7 @@ public interface  PostDAO  {
 
 
     @Query("SELECT * FROM CachedPost ORDER BY RANDOM() LIMIT 1")
-    CachedPost randomSelect();
+    List<CachedPost> randomSelect();
 
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/github/versus/offline/PostDAO.java
+++ b/app/src/main/java/com/github/versus/offline/PostDAO.java
@@ -9,7 +9,7 @@ import androidx.room.Query;
 import java.util.List;
 
 @Dao
-public interface PostDAO  {
+public interface  PostDAO  {
     @Query("SELECT * FROM CachedPost")
     List<CachedPost> getAll();
 
@@ -17,10 +17,12 @@ public interface PostDAO  {
     CachedPost loadById(String id);
 
     @Query("SELECT * FROM CachedPost WHERE id IN (:ids)")
-    List<CachedPost> loadAllByIds(int[] ids);
+    List<CachedPost> loadAllByIds(String ids[]);
 
+    /*
     @Query("SELECT * FROM CachedPost ORDER BY RANDOM() LIMIT 1")
     CachedPost randomSelect();
+    */
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insertAll(CachedPost... rows);
@@ -29,8 +31,11 @@ public interface PostDAO  {
     void deleteById(String id);
 
 
+    /*
     @Delete
     void delete(CachedPost row);
+
+     */
 
 
 }

--- a/app/src/main/java/com/github/versus/offline/PostDAO.java
+++ b/app/src/main/java/com/github/versus/offline/PostDAO.java
@@ -19,23 +19,19 @@ public interface  PostDAO  {
     @Query("SELECT * FROM CachedPost WHERE id IN (:ids)")
     List<CachedPost> loadAllByIds(String ids[]);
 
-    /*
+
     @Query("SELECT * FROM CachedPost ORDER BY RANDOM() LIMIT 1")
     CachedPost randomSelect();
-    */
+
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insertAll(CachedPost... rows);
 
+
+    @Query("SELECT * FROM CachedPost WHERE sport LIKE :sport ")
+    CachedPost loadBySport(String sport);
+
     @Query("DELETE FROM CachedPost WHERE id LIKE :id")
     void deleteById(String id);
-
-
-    /*
-    @Delete
-    void delete(CachedPost row);
-
-     */
-
 
 }

--- a/app/src/main/java/com/github/versus/offline/SimpleTestPost.java
+++ b/app/src/main/java/com/github/versus/offline/SimpleTestPost.java
@@ -31,5 +31,10 @@ public final class SimpleTestPost extends Post {
         return  new Post(title,timestamp,location,new ArrayList<>(),limit, sport);
     }
 
+    public static Post postWith(String title,Timestamp timestamp,Location location, int limit,Sport sport,DummyUser creator){
+        List<DummyUser> ls = new ArrayList<>();
+        ls.add(creator);
+        return new Post(title,timestamp,location,ls,limit, sport);
+    }
 
 }

--- a/app/src/main/java/com/github/versus/offline/SimpleTestPost.java
+++ b/app/src/main/java/com/github/versus/offline/SimpleTestPost.java
@@ -3,90 +3,32 @@ package com.github.versus.offline;
 import com.github.versus.posts.Location;
 import com.github.versus.posts.Post;
 import com.github.versus.posts.Timestamp;
+import com.github.versus.sports.Sport;
 import com.github.versus.user.DummyUser;
 
 import java.time.Month;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 
 public final class SimpleTestPost extends Post {
-    private String title = "Valid Post";
-    @Override
-    public String getTitle() {
-        return title;
-    }
-
-    @Override
-    public Timestamp getDate() {
-        return new Timestamp(Calendar.getInstance().get(Calendar.YEAR), Month.values()[0], 1, 8, 1, Timestamp.Meridiem.PM);
-    }
-
-    @Override
-    public Location getLocation() {
-        return new Location("Lausanne", 10, 10);
-    }
-
-    @Override
-    public List<DummyUser> getPlayers() {
-        return null;
-    }
-
-    @Override
-    public int getPlayerLimit() {
-        return 10;
-    }
-
-    @Override
-    public Map<String, Object> getAllAttributes() {
-        return null;
-    }
-
-    public boolean equals(Post that){
-        return this.getTitle().equals(that.getTitle()) &&
-                this.getDate().equals(that.getDate())  &&
-                this.getLocation().equals(that.getLocation()) &&
-                this.getPlayerLimit()== that.getPlayerLimit();
-    }
 
     public SimpleTestPost(){
-        title= "Valid Post";
+      this("Valid Post");
     }
     public SimpleTestPost(String title){
-        this.title= title;
+        super(title,new Timestamp(Calendar.getInstance().get(Calendar.YEAR),
+                Month.values()[0], 1, 8, 1, Timestamp.Meridiem.PM)
+                ,new Location("Lausanne", 10, 10),new ArrayList<>(),10,Sport.FOOTBALL);
+
     }
     public static Post postWith(String title,Timestamp timestamp,Location location, int limit){
-       return  new Post() {
-            @Override
-            public String getTitle() {
-                return title ;
-            }
+       return  new Post(title,timestamp,location,new ArrayList<>(),limit, Sport.FOOTBALL);
+    }
 
-            @Override
-            public Timestamp getDate() {
-                return timestamp;
-            }
-
-            @Override
-            public Location getLocation() {
-                return location;
-            }
-
-            @Override
-            public List<DummyUser> getPlayers() {
-                return null;
-            }
-
-            @Override
-            public int getPlayerLimit() {
-                return limit;
-            }
-
-            @Override
-            public Map<String, Object> getAllAttributes() {
-                return null;
-            }
-        };
+    public static Post postWith(String title,Timestamp timestamp,Location location, int limit,Sport sport){
+        return  new Post(title,timestamp,location,new ArrayList<>(),limit, sport);
     }
 
 }

--- a/app/src/main/java/com/github/versus/offline/SimpleTestPost.java
+++ b/app/src/main/java/com/github/versus/offline/SimpleTestPost.java
@@ -31,4 +31,5 @@ public final class SimpleTestPost extends Post {
         return  new Post(title,timestamp,location,new ArrayList<>(),limit, sport);
     }
 
+
 }

--- a/app/src/main/java/com/github/versus/offline/UserConverter.java
+++ b/app/src/main/java/com/github/versus/offline/UserConverter.java
@@ -1,0 +1,35 @@
+package com.github.versus.offline;
+
+import com.github.versus.sports.Sport;
+import com.github.versus.user.User;
+
+import java.util.List;
+
+public class UserConverter {
+    /*
+    public static String convertUser(User user){
+        user.getUID();
+        user.getUserName();
+        user.getFirstName();
+        user.getLastName();
+        user.getMail();
+        user.getPhone();
+        user.getCity();
+        user.getZipCode();
+        user.getRating();
+        user.getPreferredSports();
+
+        return null ;
+    }*/
+
+    public static String convertListOfSports(List<Sport> sportList,String sep){
+        StringBuilder builder = new StringBuilder();
+        for(int i =0 ; i<sportList.size();++i){
+            builder.append(sportList.get(i));
+            if(i<sportList.size()-1){
+                builder.append(sep);
+            }
+        }
+        return builder.toString();
+    }
+}

--- a/app/src/main/java/com/github/versus/offline/UserConverter.java
+++ b/app/src/main/java/com/github/versus/offline/UserConverter.java
@@ -3,7 +3,9 @@ package com.github.versus.offline;
 import com.github.versus.sports.Sport;
 import com.github.versus.user.User;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class UserConverter {
     /*
@@ -31,5 +33,10 @@ public class UserConverter {
             }
         }
         return builder.toString();
+    }
+
+    public static List<Sport> convertBackToSports(String conversion,String sep){
+        String split[]= conversion.split(sep);
+        return Arrays.asList(split).stream().map(s -> Sport.valueOf(s)).collect(Collectors.toList());
     }
 }

--- a/app/src/test/java/com/github/versus/CachedPostTest.java
+++ b/app/src/test/java/com/github/versus/CachedPostTest.java
@@ -27,11 +27,7 @@ public class CachedPostTest {
     @Test
     public void postIsInvalidWithNullTitle() {
 
-        Post post= SimpleTestPost.postWith(null,
-                new Timestamp(Calendar.getInstance().get(Calendar.YEAR)
-                        , Month.JANUARY, 1, 8, 1, Timestamp.Meridiem.PM),
-                new Location("Lausanne", 10, 10),10);
-
+        Post post= new SimpleTestPost(null);
         assertTrue(postIsInvalid(post));
     }
 
@@ -55,6 +51,13 @@ public class CachedPostTest {
     public void postIsInvalidWithValidPost() {
         Post post = new SimpleTestPost();
         assertFalse(postIsInvalid(post));
+    }
+    @Test
+    public void postWithNoSportIsInvalid(){
+        Post post = SimpleTestPost.postWith("Invalid post",
+                new Timestamp(Calendar.getInstance().get(Calendar.YEAR), Month.JANUARY, 1, 8, 1, Timestamp.Meridiem.PM),
+                new Location("Lausanne",10,10),10,null);
+        assertTrue(postIsInvalid(post));
     }
 
     @Test
@@ -89,6 +92,7 @@ public class CachedPostTest {
         CachedPost cached = CachedPost.match(post);
         assertTrue(post.equals(cached.revert()));
     }
+
 
 
 

--- a/app/src/test/java/com/github/versus/CachedPostTest.java
+++ b/app/src/test/java/com/github/versus/CachedPostTest.java
@@ -1,8 +1,10 @@
 package com.github.versus;
 
-import org.junit.Test;
-
-import static org.junit.Assert.*;
+import static com.github.versus.offline.CachedPost.computeID;
+import static com.github.versus.offline.CachedPost.match;
+import static com.github.versus.offline.CachedPost.postIsInvalid;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.github.versus.offline.CachedPost;
 import com.github.versus.offline.SimpleTestPost;
@@ -12,13 +14,10 @@ import com.github.versus.posts.Timestamp;
 import com.github.versus.sports.Sport;
 import com.github.versus.user.DummyUser;
 
+import org.junit.Test;
+
 import java.time.Month;
 import java.util.Calendar;
-
-
-import static com.github.versus.offline.CachedPost.match;
-import static com.github.versus.offline.CachedPost.postIsInvalid;
-import static com.github.versus.offline.CachedPost.computeID;
 
 public class CachedPostTest {
     @Test
@@ -104,6 +103,14 @@ public class CachedPostTest {
         CachedPost cached = CachedPost.match(post);
         assertTrue(cached.uid.equals(user.getUID()));
     }
+    @Test
+    public void matchDoesNotIntroduceInconsistentId(){
+        Post post = SimpleTestPost.postWith("Invalid post",
+                new Timestamp(Calendar.getInstance().get(Calendar.YEAR), Month.JANUARY, 1, 8, 1, Timestamp.Meridiem.PM),
+                new Location("Lausanne",10,10),10, Sport.SOCCER);
+        CachedPost cached = CachedPost.match(post);
+        assertTrue(cached.uid==null);
+    }
 
     @Test
     public void revertPreservesUserId(){
@@ -114,6 +121,16 @@ public class CachedPostTest {
         CachedPost cached = CachedPost.match(post);
         Post reverted = cached.revert();
         assertTrue(reverted.getPlayers().get(0).equals(user));
+    }
+
+    @Test
+    public void revertDoesNotIntroduceInconsistentId(){
+        Post post = SimpleTestPost.postWith("Invalid post",
+                new Timestamp(Calendar.getInstance().get(Calendar.YEAR), Month.JANUARY, 1, 8, 1, Timestamp.Meridiem.PM),
+                new Location("Lausanne",10,10),10, Sport.SOCCER);
+        CachedPost cached = CachedPost.match(post);
+        Post reverted = cached.revert();
+        assertTrue(reverted.getPlayers().isEmpty());
     }
 
 

--- a/app/src/test/java/com/github/versus/CachedPostTest.java
+++ b/app/src/test/java/com/github/versus/CachedPostTest.java
@@ -59,7 +59,7 @@ public class CachedPostTest {
 
     @Test
     public void emptyCachedPostHasCorrectID(){
-        assertTrue(new CachedPost().id.equals(CachedPost.emptyID));
+        assertTrue(new CachedPost().id.equals(CachedPost.EMPTY_ID));
     }
 
     @Test
@@ -74,7 +74,7 @@ public class CachedPostTest {
 
     @Test
     public void computeIDWithEmptyPost(){
-        assertTrue(computeID(null).equals(CachedPost.emptyID));
+        assertTrue(computeID(null).equals(CachedPost.EMPTY_ID));
     }
     @Test
     public void computeIDWithValidPost(){

--- a/app/src/test/java/com/github/versus/CachedPostTest.java
+++ b/app/src/test/java/com/github/versus/CachedPostTest.java
@@ -9,6 +9,8 @@ import com.github.versus.offline.SimpleTestPost;
 import com.github.versus.posts.Location;
 import com.github.versus.posts.Post;
 import com.github.versus.posts.Timestamp;
+import com.github.versus.sports.Sport;
+import com.github.versus.user.DummyUser;
 
 import java.time.Month;
 import java.util.Calendar;
@@ -91,6 +93,27 @@ public class CachedPostTest {
         SimpleTestPost post = new SimpleTestPost();
         CachedPost cached = CachedPost.match(post);
         assertTrue(post.equals(cached.revert()));
+    }
+
+    @Test
+    public void matchPreservesUserId(){
+        DummyUser user = new DummyUser("i play football");
+        Post post = SimpleTestPost.postWith("Invalid post",
+                new Timestamp(Calendar.getInstance().get(Calendar.YEAR), Month.JANUARY, 1, 8, 1, Timestamp.Meridiem.PM),
+                new Location("Lausanne",10,10),10, Sport.SOCCER, user);
+        CachedPost cached = CachedPost.match(post);
+        assertTrue(cached.uid.equals(user.getUID()));
+    }
+
+    @Test
+    public void revertPreservesUserId(){
+        DummyUser user = new DummyUser("i play football");
+        Post post = SimpleTestPost.postWith("Invalid post",
+                new Timestamp(Calendar.getInstance().get(Calendar.YEAR), Month.JANUARY, 1, 8, 1, Timestamp.Meridiem.PM),
+                new Location("Lausanne",10,10),10, Sport.SOCCER, user);
+        CachedPost cached = CachedPost.match(post);
+        Post reverted = cached.revert();
+        assertTrue(reverted.getPlayers().get(0).equals(user));
     }
 
 

--- a/app/src/test/java/com/github/versus/UserConverterTest.java
+++ b/app/src/test/java/com/github/versus/UserConverterTest.java
@@ -1,5 +1,6 @@
 package com.github.versus;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.github.versus.offline.CachedPost;
@@ -8,7 +9,9 @@ import com.github.versus.sports.Sport;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 
 public class UserConverterTest {
@@ -19,7 +22,6 @@ public class UserConverterTest {
         String sep = "***";
         String conversion = UserConverter.convertListOfSports(Arrays.asList(sports),sep);
         String shouldBe= Sport.FOOTBALL.name()+sep+Sport.ClIMBING.name()+sep+Sport.ROWING.name()+sep+Sport.SOCCER.name();
-        System.out.println(conversion);
         assertTrue(conversion.equals(shouldBe));
     }
 
@@ -31,4 +33,34 @@ public class UserConverterTest {
         String shouldBe= "";
         assertTrue(conversion.equals(shouldBe));
     }
+    @Test
+    public void convertBackToSportsWorks(){
+        String sep = "&";
+        String conversion ="FOOTBALL&ClIMBING&ROWING&SOCCER";
+        List<Sport>  sportList= UserConverter.convertBackToSports(conversion,sep);
+        Sport shouldBe[]= {Sport.FOOTBALL,Sport.ClIMBING,Sport.ROWING,Sport.SOCCER};
+        System.out.println(sportList);
+        assertTrue(sportList.equals(Arrays.asList(shouldBe)));
+
+    }
+    @Test
+    public void convertBackToSportsWorksWithEmptyString(){
+        String sep = "&";
+        String conversion ="";
+        List<Sport> sportList= new ArrayList<>();
+        System.out.println(sportList);
+        Sport shouldBe[]= {};
+        assertTrue(sportList.equals(Arrays.asList(shouldBe)));
+    }
+
+    @Test
+    public void convertBackToSportsIsTheInverseOfConvertListOfSports(){
+        Sport sports[]= {Sport.FOOTBALL,Sport.ClIMBING,Sport.ROWING,Sport.SOCCER};
+        String sep = "&";
+        String conversion = UserConverter.convertListOfSports(Arrays.asList(sports),sep);
+        List<Sport> sportList= UserConverter.convertBackToSports(conversion,sep);
+        assertTrue(sportList.equals(Arrays.asList(sports)));
+
+    }
+
 }

--- a/app/src/test/java/com/github/versus/UserConverterTest.java
+++ b/app/src/test/java/com/github/versus/UserConverterTest.java
@@ -1,0 +1,34 @@
+package com.github.versus;
+
+import static org.junit.Assert.assertTrue;
+
+import com.github.versus.offline.CachedPost;
+import com.github.versus.offline.UserConverter;
+import com.github.versus.sports.Sport;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+
+public class UserConverterTest {
+
+    @Test
+    public void convertListOfSportsWorks() {
+        Sport sports[]= {Sport.FOOTBALL,Sport.ClIMBING,Sport.ROWING,Sport.SOCCER};
+        String sep = "***";
+        String conversion = UserConverter.convertListOfSports(Arrays.asList(sports),sep);
+        String shouldBe= Sport.FOOTBALL.name()+sep+Sport.ClIMBING.name()+sep+Sport.ROWING.name()+sep+Sport.SOCCER.name();
+        System.out.println(conversion);
+        assertTrue(conversion.equals(shouldBe));
+    }
+
+    @Test
+    public void convertListOnEmptyStrings() {
+        Sport sports[]= {};
+        String sep = "***";
+        String conversion = UserConverter.convertListOfSports(Arrays.asList(sports),sep);
+        String shouldBe= "";
+        assertTrue(conversion.equals(shouldBe));
+    }
+}


### PR DESCRIPTION
This pull request provides a more diversified interface to fetch data from the cache more specifically matching certain conditions (sports for example or everything in the database, or a random select) in addition to inserting multiple posts at once ,it also refractors code from some files now that a concrete implementation of the cache is present. Finally, it adapts the Room database to cache the users (dummy user for now since the versus user was created this sprint and the interface user is not serialisable, which would have created a conflict with the Firebase database that cannot be resolved before all the merges ). The database however cannot store the list of user participating in posts and therefore only the creator of the post is stored right now. Storing such a complex type would require type converters , which I partially began implementing and testing (see UserConverter) but this would require another sprint.